### PR TITLE
Fix on Windows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-eval */
-const os = require('os');
 
 function getPredicate (line) {
   return /\/\/ #if (.*)/.exec(line)[1]
@@ -98,7 +97,7 @@ function commentLine (line) {
 
 module.exports = function (source) {
   try {
-    const sourceByLine = source.split(os.EOL)
+    const sourceByLine = source.split('\n')
     const blocks = searchBlocks(sourceByLine)
     const truthyBlocks = getTruthyBlocks(blocks)
     const transformedSource = commentCodeInsideBlocks(sourceByLine, truthyBlocks)


### PR DESCRIPTION
It's doesnt work on Windows when files have file encodings with '\n'.
os.EOL returns '\n\r' so we have array sourceByLine as one string instead of multivalues.
Then commentCodeInsideBlocks can't find this big string in truthyBlocks and nothing do.