### PR TITLE
pass context to truthy blocks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,7 @@ module.exports = function (source) {
   try {
     const sourceByLine = source.split(os.EOL)
     const blocks = searchBlocks(sourceByLine)
-    const truthyBlocks = getTruthyBlocks(blocks)
+    const truthyBlocks = getTruthyBlocks.call(this, blocks)
     const transformedSource = commentCodeInsideBlocks(sourceByLine, truthyBlocks)
 
     return transformedSource.join('\n')


### PR DESCRIPTION
this needed for passing arguments through webpack query, for example you have 10 targets with different languages, this will let to pass lang as a query to every build
// #if this.query.lang === 'En'
--- do something ---
// #endif