### PR TITLE
Add a way to pass local variables as options

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,32 @@ import reduxLogger from 'redux-logger'
 // #endif
 ```
 
+You can pass variables as options to the loader:
+
+```js
+// webpack.config.js
+module: {
+  rules: [{
+    test: /\.js$/,
+    use: [
+      'babel-loader',
+      {
+        loader: 'webpack-conditional-loader',
+        options: {
+          isReady: true
+        }
+    ]
+  }]
+}
+```
+```js
+// myFile.js
+// #if isReady
+console.log(`I'm ready!`)
+// #endif
+
+```
+
 ## Credits
 - [GCC C conditional documentation](https://gcc.gnu.org/onlinedocs/gcc-3.0.2/cpp_4.html)
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "src/",
     "test/"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "loader-utils": "^1.2.3"
+  },
   "devDependencies": {
     "standard": "^10.0.2",
     "tap": "^10.7.0",

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,8 @@ const truthy = require('../build/truthy')
 const falsey = require('../build/falsey')
 const envVarTruthy = require('../build/env-var-truthy')
 const envVarFalsey = require('../build/env-var-falsey')
+const localVarTruthy = require('../build/local-var-truthy')
+const localVarFalsey = require('../build/local-var-falsey')
 
 tap.test('comment blocks with falsey predicate', (test) => {
   test.equal(falsey, 1)
@@ -21,5 +23,15 @@ tap.test('dont comment env var blocks with truthy predicate', (test) => {
 
 tap.test('comment env var blocks with falsey predicate', (test) => {
   test.equal(envVarFalsey, 1)
+  test.end()
+})
+
+tap.test('comment env var blocks with falsey predicate', (test) => {
+  test.equal(localVarFalsey, true)
+  test.end()
+})
+
+tap.test('comment env var blocks with falsey predicate', (test) => {
+  test.equal(localVarTruthy, true)
   test.end()
 })

--- a/test/test-files/local-var-falsey.js
+++ b/test/test-files/local-var-falsey.js
@@ -1,0 +1,7 @@
+let a = true
+
+// #if localVar.falsey
+a = false
+// #endif
+
+module.exports = a

--- a/test/test-files/local-var-truthy.js
+++ b/test/test-files/local-var-truthy.js
@@ -1,0 +1,7 @@
+let a = false
+
+// #if localVar.truthy
+a = true
+// #endif
+
+module.exports = a

--- a/webpack.js
+++ b/webpack.js
@@ -5,6 +5,8 @@ module.exports = {
   entry: {
     'env-var-truthy': './test/test-files/env-var-truthy.js',
     'env-var-falsey': './test/test-files/env-var-falsey.js',
+    'local-var-truthy': './test/test-files/local-var-truthy.js',
+    'local-var-falsey': './test/test-files/local-var-falsey.js',
     'falsey': './test/test-files/falsey.js',
     'truthy': './test/test-files/truthy.js'
   },
@@ -21,7 +23,15 @@ module.exports = {
   module: {
     rules: [{
       test: /\.js$/,
-      use: ['conditional-loader']
+      use: [{
+        loader: 'conditional-loader',
+        options: {
+          localVar: {
+            truthy: true,
+            falsey: false
+          }
+        }
+      }]
     }]
   }
 }


### PR DESCRIPTION
I needed specific variables passed to the loader so I could use them directly in my predicates.
Here it is, fully tested and documented.

I guess it's similar to #12, but different enough 😉 

Thanks for this helpful loader!